### PR TITLE
Removed account saving in Economy.yml

### DIFF
--- a/resources/Economy.yml
+++ b/resources/Economy.yml
@@ -19,6 +19,3 @@ worth:
   56: 50
   262: 10
   364: 15
-
-# The balance of all the players
-player-balances: []


### PR DESCRIPTION
Saving all player economy accounts in Economy.yml isn't such a good idea. You should make a separate  file for data saving.