### PR TITLE
Fixes issue #231 (null passed to function)

### DIFF
--- a/src/EssentialsPE/BaseFiles/BaseAPI.php
+++ b/src/EssentialsPE/BaseFiles/BaseAPI.php
@@ -726,7 +726,7 @@ class BaseAPI{
     /**
      * @param string $location
      */
-    public function setServerGeoLocation(string $location){
+    public function setServerGeoLocation(string $location = null){
         if($this->serverGeoLocation === null){
             $this->serverGeoLocation = $location;
         }


### PR DESCRIPTION
By adding "= null", this becomes the default for the function; and null is then allowed.

This fixes a nasty crash.