### PR TITLE
Update BaseAPI.php, VanishCommand.php

### DIFF
--- a/src/EssentialsPE/BaseFiles/BaseAPI.php
+++ b/src/EssentialsPE/BaseFiles/BaseAPI.php
@@ -1237,9 +1237,11 @@ class BaseAPI{
         if($ev->isCancelled()){
             return false;
         }
-        $this->getSession($player)->setMuted($ev->willMute(), $ev->getMutedUntil());
-        if($notify && $player->hasPermission("essentials.mute.notify")){
-            $player->sendMessage(TextFormat::YELLOW . "You where " . ($this->isMuted($player) ? "muted " . ($ev->getMutedUntil() !== null ? "until: " . TextFormat::AQUA . $ev->getMutedUntil()->format("l, F j, Y") . TextFormat::RED . " at " . TextFormat::AQUA . $ev->getMutedUntil()->format("h:ia") : TextFormat::AQUA . "Forever" . TextFormat::YELLOW . "!") : "unmuted!"));
+        if($this->isMuted($player) != $state){ //Only do this if the mute state is changing. This fixes the message on server reload.
+            $this->getSession($player)->setMuted($ev->willMute(), $ev->getMutedUntil());
+            if($notify && $player->hasPermission("essentials.mute.notify")){
+                $player->sendMessage(TextFormat::YELLOW . "You have been " . ($this->isMuted($player) ? "muted " . ($ev->getMutedUntil() !== null ? "until: " . TextFormat::AQUA . $ev->getMutedUntil()->format("l, F j, Y") . TextFormat::RED . " at " . TextFormat::AQUA . $ev->getMutedUntil()->format("h:ia") : TextFormat::AQUA . "Forever" . TextFormat::YELLOW . "!") : "unmuted!"));
+            }
         }
         return true;
     }

--- a/src/EssentialsPE/Commands/Override/Gamemode.php
+++ b/src/EssentialsPE/Commands/Override/Gamemode.php
@@ -116,7 +116,7 @@ class Gamemode extends BaseOverrideCommand{
             $player->sendMessage("Your game mode has been updated");
         }
         $player->setGamemode($gm);
-		Command::broadcastCommandMessage($sender, "Set ".($player === $sender? "own": $player->getName()."'s")." game mode to ".$gmstring);
+	Command::broadcastCommandMessage($sender, "Set ".($player === $sender? "own": $player->getName()."'s")." game mode to ".$gmstring);
         return true;
     }
 

--- a/src/EssentialsPE/Commands/Override/Gamemode.php
+++ b/src/EssentialsPE/Commands/Override/Gamemode.php
@@ -3,6 +3,7 @@ namespace EssentialsPE\Commands\Override;
 
 use EssentialsPE\BaseFiles\BaseAPI;
 use pocketmine\command\CommandSender;
+use pocketmine\command\Command;
 use pocketmine\Player;
 use pocketmine\utils\TextFormat;
 
@@ -108,13 +109,14 @@ class Gamemode extends BaseOverrideCommand{
         }
         $gmstring = $this->getAPI()->getServer()->getGamemodeString($gm);
         if($player->getGamemode() === $gm){
-            $player->sendMessage(TextFormat::RED . "[Error] " . ($player === $sender ? "You're" : $args[1] . " is") . " already in " . $gmstring . " mode");
+            $sender->sendMessage(TextFormat::RED . "[Error] " . ($player === $sender ? "You're" : $player->getName() . " is") . " already in " . $gmstring);
             return false;
         }
         if($player !== $sender){
-            $sender->sendMessage(TextFormat::GREEN . $args[1] . " is now in " . $gmstring . " mode");
+            $player->sendMessage("Your game mode has been updated");
         }
         $player->setGamemode($gm);
+		Command::broadcastCommandMessage($sender, "Set ".($player === $sender? "own": $player->getName()."'s")." game mode to ".$gmstring);
         return true;
     }
 

--- a/src/EssentialsPE/Commands/Vanish.php
+++ b/src/EssentialsPE/Commands/Vanish.php
@@ -53,25 +53,6 @@ class Vanish extends BaseCommand{
                 return false;
                 break;
         }
-        if((!isset($args[0]) && !$sender instanceof Player) || count($args) > 1){
-            $this->sendUsage($sender, $alias);
-            return false;
-        }
-        $player = $sender;
-        if(isset($args[0])){
-            if(!$sender->hasPermission("essentials.vanish.other")){
-                $sender->sendMessage($this->getPermissionMessage());
-                return false;
-            }elseif(!($player = $this->getAPI()->getPlayer($args[0]))){
-                $sender->sendMessage(TextFormat::RED . "[Error] Player not found");
-                return false;
-            }
-        }
-        $this->getAPI()->switchVanish($player);
-        $player->sendMessage(TextFormat::GRAY . "You're now " . ($s = $this->getAPI()->isVanished($player) ? "vanished" : "visible"));
-        if($player !== $sender){
-            $sender->sendMessage(TextFormat::GRAY .  $player->getDisplayName() . " is now $s");
-        }
         return true;
     }
 }


### PR DESCRIPTION
- Change "You where unmuted!" to "You have been unmuted!", better spelling, makes more sense
- Fixed the "You where unmuted!" message on server reload by adding a condition to check if the new mute state is different from the current state.